### PR TITLE
Allow multiple possible answers

### DIFF
--- a/class.addregistrationquestion.plugin.php
+++ b/class.addregistrationquestion.plugin.php
@@ -65,7 +65,7 @@ class AddRegistrationQuestion extends Gdn_Plugin {
     private function isCorrect($attempt = '') {
         $answers = explode(',', $this->answer());
 
-        for ($answers as $answer) {
+        foreach ($answers as $answer) {
             if (strcasecmp(trim($answer), $attempt)) {
                 return true;
             }

--- a/class.addregistrationquestion.plugin.php
+++ b/class.addregistrationquestion.plugin.php
@@ -27,7 +27,7 @@ class AddRegistrationQuestion extends Gdn_Plugin {
 
 
     public function entryController_registerValidation_handler($sender) {
-        if (strcasecmp($sender->Form->getValue('Question'), $this->answer()) !== 0) {
+        if (!$this->isCorrect($sender->Form->getValue('Question'))) {
             $sender->Form->addError('The security question was answered incorrectly.');
             $sender->render();
             exit();
@@ -60,6 +60,19 @@ class AddRegistrationQuestion extends Gdn_Plugin {
         $sender->title('Registration Question');
         $conf->renderAll();
     }
+
+
+    private function isCorrect($attempt = '') {
+        $answers = explode(',', $this->answer());
+
+        for ($answers as $answer) {
+            if (strcasecmp(trim($answer), $attempt)) {
+                return true;
+            }
+        }
+
+        return false;
+    }   
 
 
     private function question() {

--- a/class.addregistrationquestion.plugin.php
+++ b/class.addregistrationquestion.plugin.php
@@ -66,7 +66,7 @@ class AddRegistrationQuestion extends Gdn_Plugin {
         $answers = explode(',', $this->answer());
 
         foreach ($answers as $answer) {
-            if (strcasecmp(trim($answer), $attempt)) {
+            if (strcasecmp(trim($answer), $attempt) == 0) {
                 return true;
             }
         }


### PR DESCRIPTION
I use this plugin, but occasionally users answer slightly incorrectly. Either they mistype a letter, or they use the plural form of the correct answer, or they use a different spelling (e.g. color vs colour). To make my life easier, I refactored this to allow multiple, comma-delimited answers.