### PR TITLE
Fix Plugins Class Name

### DIFF
--- a/class.addregistrationquestion.plugin.php
+++ b/class.addregistrationquestion.plugin.php
@@ -12,7 +12,7 @@ $PluginInfo['AddRegistrationQuestion'] = [
     'GitHub' => 'bleistivt/AddRegistrationQuestion'
 ];
 
-class AddRegistrationQuestion extends Gdn_Plugin {
+class AddRegistrationQuestionPlugin extends Gdn_Plugin {
 
     public function gdn_dispatcher_appStartup_handler() {
         if (c('AddRegistrationQuestion.Basic')) {


### PR DESCRIPTION
Vanilla 2.5 is more strict concerning the required class names for plugins: https://open.vanillaforums.com/discussion/35697/general-2-5-plugin-compatibility-issues